### PR TITLE
chore(build.go): bump docker-compose version

### DIFF
--- a/pkg/docker-compose/build.go
+++ b/pkg/docker-compose/build.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const dockerComposeVersion = "1.25.4"
+const dockerComposeVersion = "1.26.0"
 
 // Build installs the docker and docker-compose binaries
 func (m *Mixin) Build() error {

--- a/pkg/docker-compose/build_test.go
+++ b/pkg/docker-compose/build_test.go
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y python3-pip wget && pip3 install --upgr
   mv docker/docker /usr/bin/docker && \
   chmod +x /usr/bin/docker && \
   rm -rf docker/ docker-${DOCKER_VERSION}.tgz && \
-  pip3 install docker-compose==1.25.4
+  pip3 install docker-compose==1.26.0
 `
 
 	t.Run("build", func(t *testing.T) {


### PR DESCRIPTION
* Bumps the default `docker-compose` version to the latest per https://docs.docker.com/compose/install/

With the previous version, I was seeing the following when attempting to use/reference `secrets` in my compose file:
```
The Compose file './docker-compose.yaml' is invalid because:
Invalid top-level property "secrets". Valid top-level sections for this Compose file are: version, services, networks, volumes, and extensions starting with "x-".
```


Depends on/blocked by https://github.com/deislabs/porter-docker-compose/pull/9